### PR TITLE
fix: race poll timeout against blocking HTTP calls in interactive mode

### DIFF
--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -192,7 +192,22 @@ export async function* pollCommandWithTimeout(
 
   while (Date.now() - startTime < executionTimeout) {
     try {
-      const result = await doReceiveOutputNonBlocking(params);
+      const remaining = executionTimeout - (Date.now() - startTime);
+      if (remaining <= 0) break;
+
+      // Race the HTTP call against the remaining execution timeout
+      const result = await Promise.race([
+        doReceiveOutputNonBlocking(params),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () =>
+              reject(
+                new Error(`Polling timed out after ${executionTimeout}ms`)
+              ),
+            remaining
+          )
+        ),
+      ]);
 
       yield result;
 

--- a/tests/e2e/interactive.e2e.test.ts
+++ b/tests/e2e/interactive.e2e.test.ts
@@ -125,11 +125,11 @@ describe('interactive commands', () => {
         JEST_WINRM_PASS,
         5985,
         prompts,
-        5000, // 5 second timeout for quicker test
-        6000 // 6 second http timeout for quicker test
+        2000, // 2 second execution timeout
+        3000 // 3 second http timeout
       )
     ).rejects.toThrow('timed out');
-  }, 10000);
+  }, 15000);
 
   it('should handle commands that complete without interaction', async () => {
     const prompts: InteractivePromptOutput[] = [


### PR DESCRIPTION
## Summary
- `pollCommandWithTimeout` could hang indefinitely when `doReceiveOutputNonBlocking` blocked on a WinRM long-poll (e.g. `Read-Host` waiting for user input), because the execution timeout was only checked between poll iterations
- Use `Promise.race` to enforce the execution timeout even when the HTTP call hasn't returned yet
- Reduced test timeouts for the timeout test case (2s execution, 3s http) to keep e2e suite fast

## Test plan
- [x] `npm run jest:e2e` — all 13 tests pass (1 skipped)
- [x] "should timeout when no matching prompt is found" now completes in ~2.5s instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)