### PR TITLE
feat: trigger release on push to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
 on:
+  push:
+    branches: [master]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Add `push` trigger on `master` branch to the release workflow
- Keeps `workflow_dispatch` for manual releases
- Merging any PR into master will now automatically bump version and publish to npm

## Test plan
- [ ] Merge this PR — it should trigger the Release workflow automatically
- [ ] Verify version bump, npm publish, and git tag push all succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)